### PR TITLE
Small tweaks / fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ Sample usage:
 ```
 JIRA_USER=foo JIRA_PASS=bar ./bin/graphcmd -jira-host=subdomain.atlassian.net -initial-estimate-field=timeoriginalestimate -estimate-field=customfield_10001
 ```
+JIRA_PASS can be a password or API Token
+
+To discover field IDs for passing as flag values, your JIRA instance's [issue fields](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-group-issue-fields) can be found like:
+```
+curl https://subdomain.atlassian.net/rest/api/2/field --user <JIRA_USER>:<JIRA_PASS>
+```

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ go get -u github.com/andrei-m/jira-graph
 
 Sample usage:
 ```
-JIRA_USER=foo JIRA_PASS=bar ./bin/graphcmd -jira-host=subdomain.atlassian.net -default-project=PROJ
+JIRA_USER=foo JIRA_PASS=bar ./bin/graphcmd -jira-host=subdomain.atlassian.net -initial-estimate-field=timeoriginalestimate -estimate-field=customfield_10001
 ```

--- a/graph.go
+++ b/graph.go
@@ -101,7 +101,7 @@ func getIssues(jc jiraClient, epicKeys ...string) ([]issue, error) {
 	if len(epicKeys) == 0 {
 		return nil, errors.New("at least one epic key is required")
 	}
-	jql := fmt.Sprintf(`"Epic Link" IN (%s)`, strings.Join(epicKeys, ","))
+	jql := fmt.Sprintf(`"%s" IN (%s)`, jc.fieldConfig.EpicLink, strings.Join(epicKeys, ","))
 	return getIssuesJQL(jc, jql)
 }
 

--- a/jira.go
+++ b/jira.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -176,7 +177,14 @@ type sprint struct {
 func parseSprint(rawSprint string) (sprint, error) {
 	bracketIdx := strings.Index(rawSprint, "[")
 	if bracketIdx == -1 {
-		return sprint{}, fmt.Errorf("couldn't find opening '[' in: %s", rawSprint)
+		var singleSprint sprint
+		if err := json.Unmarshal([]byte(rawSprint), &singleSprint); err != nil {
+			return sprint{}, err
+		}
+		if singleSprint.ID > 0 && len(singleSprint.Name) > 0 {
+			return singleSprint, nil
+		}
+		return sprint{}, fmt.Errorf("couldn't find opening '[' or Cloud-JIRA sprint json in: %s", rawSprint)
 	}
 	trimmed := rawSprint[bracketIdx+1 : len(rawSprint)-1]
 

--- a/jira_test.go
+++ b/jira_test.go
@@ -23,6 +23,21 @@ func Test_parseSprint(t *testing.T) {
 		assert.Equal(t, expected, spr)
 	})
 
+	t.Run("cloud JIRA sprint", func(t *testing.T) {
+		raw := `{"id":80,"name":"native JIRA sprint json","state":"closed","boardId":1,"foo":"arbitrary extra field","startDate":"2021-10-12T15:20:44.479Z","endDate":"2021-10-25T04:00:00.000Z","completeDate":"2021-10-25T14:06:51.325Z"}`
+		spr, err := parseSprint(raw)
+		assert.NoError(t, err)
+		expected := sprint{
+			ID:        80,
+			State:     "closed",
+			Name:      "native JIRA sprint json",
+			StartDate: time.Date(2021, 10, 12, 15, 20, 44, int(479*time.Millisecond), time.UTC),
+			EndDate:   time.Date(2021, 10, 25, 4, 0, 0, 0, time.UTC),
+			Sequence:  0,
+		}
+		assert.Equal(t, expected, spr)
+	})
+
 	t.Run("null dates", func(t *testing.T) {
 		raw := "com.atlassian.greenhopper.service.sprint.Sprint@153f4085[id=288,rapidViewId=243,state=FUTURE,name=Alf 9/17 planning,goal=,startDate=<null>,endDate=<null>,completeDate=<null>,sequence=287]"
 		spr, err := parseSprint(raw)

--- a/src/graph.js
+++ b/src/graph.js
@@ -623,7 +623,7 @@ class EpicStats extends React.Component {
 
         if (totalPoints > 0) {
             rows.push(<tr className="total"><td>Total</td><td className="points">{totalPoints}</td></tr>);
-            var closedPoints = byStatus['Closed'] ? byStatus['Closed'] : 0;
+            var closedPoints = byStatus[statuses.Closed] ? byStatus[statuses.Closed] : 0;
             const closedPercent = Math.round(closedPoints / totalPoints * 100);
             rows.push(<tr className="total"><td colspan="2">{closedPoints}/{totalPoints} Closed ({closedPercent}%)</td></tr>)
         }


### PR DESCRIPTION
A couple small fixes to use constants/config instead of hard-coded strings, and support for what I assume is the Cloud-JIRA native representation of a sprint, based solely on the cloud instance I'm testing against