### PR TITLE
Embed assets and templates for deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ build: test preprocess
 	npm run-script build
 	go install github.com/andrei-m/jira-graph/graphcmd
 
+dev: test
+	npm install
+	npm run-script build
+	go install -tags dev github.com/andrei-m/jira-graph/graphcmd
+
 test:
 	go test
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -7,8 +7,6 @@ Libraries:
 * look into gephi
 
 Infrastructure
-* quick package script that bundles the binary with 'static' and 'templates'
-* or single binary deploy
 * systemd unit file for deployment
 
 clean up items:

--- a/graphcmd/main.go
+++ b/graphcmd/main.go
@@ -15,7 +15,7 @@ var (
 	flaggedField         = flag.String("flagged-field", "customfield_10002", "the name of the custom field for impediment flagging")
 	sprintsField         = flag.String("sprints-field", "customfield_10007", "the name of the custom field for Greenhopper sprints")
 	epicLinkField        = flag.String("epic-link-field", "customfield_10200", "the name of the custom field for Epic Link")
-	useLiveFiles         = flag.Bool("use-live-files", false, "use live templates and assets instead of embedding, for faster iteration during local development")
+	useLiveFiles         = false
 )
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 		EpicLink:        *epicLinkField,
 	}
 
-	if err := graph.StartServer(user, pass, *jiraHost, fc, *useLiveFiles); err != nil {
+	if err := graph.StartServer(user, pass, *jiraHost, fc, useLiveFiles); err != nil {
 		log.Fatalf("server failed with error: %v", err)
 	}
 }

--- a/graphcmd/main.go
+++ b/graphcmd/main.go
@@ -15,6 +15,7 @@ var (
 	flaggedField         = flag.String("flagged-field", "customfield_10002", "the name of the custom field for impediment flagging")
 	sprintsField         = flag.String("sprints-field", "customfield_10007", "the name of the custom field for Greenhopper sprints")
 	epicLinkField        = flag.String("epic-link-field", "customfield_10200", "the name of the custom field for Epic Link")
+	useLiveFiles         = flag.Bool("use-live-files", false, "use live templates and assets instead of embedding, for faster iteration during local development")
 )
 
 func main() {
@@ -40,7 +41,7 @@ func main() {
 		EpicLink:        *epicLinkField,
 	}
 
-	if err := graph.StartServer(user, pass, *jiraHost, fc); err != nil {
+	if err := graph.StartServer(user, pass, *jiraHost, fc, *useLiveFiles); err != nil {
 		log.Fatalf("server failed with error: %v", err)
 	}
 }

--- a/graphcmd/main_dev.go
+++ b/graphcmd/main_dev.go
@@ -1,0 +1,13 @@
+//go:build dev
+// +build dev
+
+package main
+
+import "flag"
+
+var devServer = flag.Bool("use-live-files", false, "use live templates and assets instead of embedding, for faster iteration during local development")
+
+func init() {
+	flag.Parse()
+	useLiveFiles = *devServer
+}

--- a/server.go
+++ b/server.go
@@ -40,7 +40,7 @@ func loadAssets(r *gin.Engine, useLiveFiles bool) {
 	r.StaticFS("/assets", http.FS(assetsFS))
 }
 
-func StartServer(user, pass, jiraHost string, fc FieldConfig) error {
+func StartServer(user, pass, jiraHost string, fc FieldConfig, useLiveFiles bool) error {
 	jc := jiraClient{
 		host:        jiraHost,
 		user:        user,
@@ -52,8 +52,8 @@ func StartServer(user, pass, jiraHost string, fc FieldConfig) error {
 	}
 
 	r := gin.Default()
-	loadTemplates(r, false)
-	loadAssets(r, false)
+	loadTemplates(r, useLiveFiles)
+	loadAssets(r, useLiveFiles)
 
 	r.GET("/api/epics/:key", gc.getEpicGraph)
 	r.GET("/api/issues/:key/related", gc.getRelatedIssues)

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -3,11 +3,11 @@
   <head>
     <title>jiragraph</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
-    <link href="/assets/index.css" rel="stylesheet" />
+    <link href="/assets/dist/index.css" rel="stylesheet" />
   </head>
   <body>
 	<h1>jiragraph</h1>
 	<div id="root"></div>
-    <script src="/assets/index.js"></script>
+    <script src="/assets/dist/index.js"></script>
   </body>
 </html>

--- a/templates/issue.tmpl
+++ b/templates/issue.tmpl
@@ -3,7 +3,7 @@
   <head>
     <title>jiragraph: {{ .issue.Key }} - {{ .issue.Summary }}</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
-    <link href="/assets/graph.css" rel="stylesheet" />
+    <link href="/assets/dist/graph.css" rel="stylesheet" />
   </head>
   <body>
 	<div id="root"
@@ -16,6 +16,6 @@
 		data-issue-assignee-image-url="{{.issue.AssigneeImageURL}}"
 		data-jira-host="{{.jiraHost}}">
 	</div>
-    <script src="/assets/graph.js"></script>
+    <script src="/assets/dist/graph.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Tested this at least locally on Go 1.17, there shouldn't be any issues on 1.16 (assuming that's what this was built with? `embed` requires that) but this should maybe be blocked on updating the project to a more recent Go version + module file - happy to open a PR doing that if there's interest

This has a weird intersection with `embed`, notably that the embedded directory is part of the filename of everything in the fs. I opted for the slightly-simpler code that accommodates this by including `dist` in the resource URIs on the templates. If this isn't desired, it could be worked around with the following change and reverting the template changes:
```go
func loadAssets(r *gin.Engine, useLiveFiles bool) {
	if useLiveFiles {
		r.StaticFS("/assets", gin.Dir("./dist", false))
		return
	}
	subFS, err := fs.Sub(assetsFS, "dist")
	if err != nil {
		// this should only happen if `dist/` is renamed
		panic(err)
	}
	r.StaticFS("/assets", http.FS(subFS))
}
```