### PR TITLE
Smaller bin sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 build: test preprocess
 	npm install
 	npm run-script build
-	go install github.com/andrei-m/jira-graph/graphcmd
+	go install -tags=nomsgpack github.com/andrei-m/jira-graph/graphcmd
 
 dev: test
 	npm install
 	npm run-script build
-	go install -tags dev github.com/andrei-m/jira-graph/graphcmd
+	go install -tags=nomsgpack,dev github.com/andrei-m/jira-graph/graphcmd
 
 test:
 	go test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build: test preprocess
 	npm install
 	npm run-script build
-	go install -tags=nomsgpack github.com/andrei-m/jira-graph/graphcmd
+	go install -tags=nomsgpack -ldflags="-s -w" github.com/andrei-m/jira-graph/graphcmd
 
 dev: test
 	npm install


### PR DESCRIPTION
A couple small tweaks:
* Drop MsgPack support - its unused in `jira-graph`, and Gin solved their regret of default-including it by adding a build tag `nomsgpack`
* Use linker flags to drop debug info - symbol table and DWARF generation aren't necessary or useful for a released/production build, and constitute nearly a third of the binary size

Comparison of sizes from current to final after these changes:
```
$ go install github.com/andrei-m/jira-graph/graphcmd
$ ls -lha /home/bgarf/go/bin | grep graphcmd
-rwxr-xr-x 1 bgarf bgarf  16M Jan 25 11:24 graphcmd

$ go install -tags=nomsgpack github.com/andrei-m/jira-graph/graphcmd
$ ls -lha /home/bgarf/go/bin | grep graphcmd
-rwxr-xr-x 1 bgarf bgarf  15M Jan 25 11:25 graphcmd

$ go install -tags=nomsgpack -ldflags="-s -w" github.com/andrei-m/jira-graph/graphcmd
$ ls -lha /home/bgarf/go/bin | grep graphcmd
-rwxr-xr-x 1 bgarf bgarf  11M Jan 25 11:26 graphcmd
```