### PR TITLE
Prettier formatting

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/eslintrc.json
 extends:
   - 'eslint:recommended'
   - 'plugin:react/recommended'
@@ -14,6 +15,7 @@ ignorePatterns:
   - 'dist'
 rules:
   no-var: error
+  prefer-template: error
   semi: error
   quotes: ['error', 'single']
   jsx-quotes: ['error', 'prefer-single']

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,7 @@
 extends:
   - 'eslint:recommended'
   - 'plugin:react/recommended'
+  - 'plugin:prettier/recommended'
 env:
   browser: true
   es6: true
@@ -17,3 +18,10 @@ rules:
   quotes: ['error', 'single']
   jsx-quotes: ['error', 'prefer-single']
   react/prop-types: ['off'] # TODO: enable this, or switch to TypeScript
+  prettier/prettier:
+    - error
+    - singleQuotes: true
+      jsxSingleQuote: true
+      printWidth: 120
+      tabWidth: 4
+      trailingComma: all

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+dist
+*.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+singleQuote: true
+jsxSingleQuote: true
+printWidth: 120
+tabWidth: 4
+trailingComma: all
+
+# yaml-language-server: $schema=https://json.schemastore.org/prettierrc.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@babel/preset-env": "^7.16.11",
         "@vitejs/plugin-react": "^1.0.7",
         "eslint": "^8.34.0",
+        "eslint-config-prettier": "^8.6.0",
+        "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.2",
         "vite": "^2.9.15"
       }
@@ -3162,6 +3164,39 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.32.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
@@ -3435,6 +3470,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4488,6 +4529,34 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/prop-types": {
@@ -7452,6 +7521,22 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.32.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
@@ -7581,6 +7666,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -8326,6 +8417,22 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "prettier": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "dev": true,
+      "peer": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@babel/preset-env": "^7.16.11",
     "@vitejs/plugin-react": "^1.0.7",
     "eslint": "^8.34.0",
+    "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "vite": "^2.9.15"
   },

--- a/src/Errors.jsx
+++ b/src/Errors.jsx
@@ -8,6 +8,4 @@ function NotFound() {
     );
 }
 
-export {
-    NotFound
-};
+export { NotFound };

--- a/src/Graph.jsx
+++ b/src/Graph.jsx
@@ -60,23 +60,23 @@ class Popup extends React.Component {
         const yOffset = 45;
 
         const style = {
-            left: this.props.selectedEpic.popupPosition.x + 'px',
-            top: this.props.selectedEpic.popupPosition.y + yOffset + 'px',
+            left: `${this.props.selectedEpic.popupPosition.x}px`,
+            top: `${this.props.selectedEpic.popupPosition.y + yOffset}px`,
         };
 
         const epic = this.props.selectedEpic.epic;
 
         let className = 'popup';
         if (epic.flagged) {
-            className = className + ' flagged';
+            className = `${className} flagged`;
         }
 
         return (
             <div className={className} style={style}>
                 <div className='popup-summary'>{epic.summary}</div>
                 <div className='popup-container'>
-                    <PopupIcon alt={'Type: ' + epic.type} imageURL={epic.typeImageURL} />
-                    <PopupIcon alt={'Priority: ' + epic.priority} imageURL={epic.priorityImageURL} />
+                    <PopupIcon alt={`Type: ${epic.type}`} imageURL={epic.typeImageURL} />
+                    <PopupIcon alt={`Priority: ${epic.priority}`} imageURL={epic.priorityImageURL} />
                     <span className='popup popup-flagged'>{epic.flagged ? '⚑' : ''}</span>
                     <PopupEstimate estimate={epic.estimate} />
                     <PopupKey epicKey={epic.key} />
@@ -119,7 +119,7 @@ class PopupAssignee extends React.Component {
             return <span className='popup-avatar' />;
         }
 
-        const alt = 'Assignee: ' + this.props.assignee;
+        const alt = `Assignee: ${this.props.assignee}`;
         return (
             <span className='popup-avatar'>
                 <img src={this.props.assigneeImageURL} alt={alt} title={alt} />
@@ -130,7 +130,7 @@ class PopupAssignee extends React.Component {
 
 class PopupKey extends React.Component {
     render() {
-        const url = '/api/issues/' + this.props.epicKey + '/details';
+        const url = `/api/issues/${this.props.epicKey}/details`;
 
         return (
             <span className='popup-key'>
@@ -217,7 +217,7 @@ class GraphApp extends React.Component {
 
     componentDidMount() {
         const issueKey = this.props.issueKey;
-        console.log('loading ' + issueKey);
+        console.log(`loading ${issueKey}`);
         const uriPrefix = this.props.issueType === 'Milestone' ? '/api/milestones/' : '/api/epics/';
 
         fetch(uriPrefix + issueKey)
@@ -233,10 +233,10 @@ class GraphApp extends React.Component {
                     issueGraph: result,
                     selectedEpics: this.initSelectedEpics(result),
                 });
-                console.log('loaded ' + issueKey);
+                console.log(`loaded ${issueKey}`);
             })
             .catch((err) => {
-                console.log('failed to load ' + issueKey + ' error: ' + err);
+                console.log(`failed to load ${issueKey} error: ${err}`);
                 this.setState({
                     isLoaded: false,
                     error: true,
@@ -322,8 +322,8 @@ class RelatedIssues extends React.Component {
     componentDidMount() {
         const issueKey = this.props.issueKey;
 
-        console.log('loading related issues for ' + issueKey);
-        fetch('/api/issues/' + issueKey + '/related')
+        console.log(`loading related issues for ${issueKey}`);
+        fetch(`/api/issues/${issueKey}/related`)
             .then((res) => {
                 if (!res.ok) {
                     throw new Error('not ok');
@@ -335,10 +335,10 @@ class RelatedIssues extends React.Component {
                     isLoaded: true,
                     issues: result,
                 });
-                console.log('loaded related issues for ' + issueKey);
+                console.log(`loaded related issues for ${issueKey}`);
             })
             .catch(() => {
-                console.log('failed to load related issues for ' + issueKey);
+                console.log(`failed to load related issues for ${issueKey}`);
                 this.setState({
                     isLoaded: false,
                     error: true,
@@ -530,7 +530,7 @@ class Graph extends React.Component {
             const blockingIssue = iss.data.id;
             return issueGraph.graph[blockingIssue].flatMap((blockedIssue) => {
                 if (!issueKeys.has(blockedIssue)) {
-                    console.log('skipping edge for unselected epic issue ' + blockedIssue);
+                    console.log(`skipping edge for unselected epic issue ${blockedIssue}`);
                     return [];
                 }
                 return [
@@ -582,8 +582,8 @@ class IssueGraph extends React.Component {
             return <div>Loading...</div>;
         }
         const issue = this.state.issue;
-        const issueURL = 'https://' + this.state.jiraHost + '/browse/' + issue.key;
-        const issueLabel = issue.key + ' - ' + issue.summary;
+        const issueURL = `https://${this.state.jiraHost}/browse/${issue.key}`;
+        const issueLabel = `${issue.key} - ${issue.summary}`;
         return (
             <div>
                 <h1>
@@ -623,8 +623,8 @@ class IssueGraph extends React.Component {
     componentDidMount() {
         const issueKey = this.props.issueKey;
 
-        console.log('loading related issues for ' + issueKey);
-        fetch('/api/issues/' + issueKey)
+        console.log(`loading related issues for ${issueKey}`);
+        fetch(`/api/issues/${issueKey}`)
             .then((res) => {
                 if (!res.ok) {
                     throw new Error('not ok');
@@ -646,10 +646,10 @@ class IssueGraph extends React.Component {
                     summary: result.issue.summary,
                 };
                 pushRecentIssue(issue);
-                console.log('loaded issue ' + issueKey);
+                console.log(`loaded issue ${issueKey}`);
             })
             .catch((err) => {
-                console.log('failed to load issue ' + issueKey + ' error: ' + err);
+                console.log(`failed to load issue ${issueKey} error: ${err}`);
                 this.setState((prevState) => ({
                     ...prevState,
                     ...{

--- a/src/Graph.jsx
+++ b/src/Graph.jsx
@@ -1,14 +1,8 @@
 import cytoscape from 'cytoscape';
 import React from 'react';
-import {
-    useParams
-} from 'react-router-dom';
-import {
-    pushRecentIssue
-} from './recent';
-import {
-    colors
-} from './colors';
+import { useParams } from 'react-router-dom';
+import { pushRecentIssue } from './recent';
+import { colors } from './colors';
 import './graph.css';
 
 //TODO: these statuses are all implementation-specific and should be made customizable.
@@ -67,7 +61,7 @@ class Popup extends React.Component {
 
         const style = {
             left: this.props.selectedEpic.popupPosition.x + 'px',
-            top: (this.props.selectedEpic.popupPosition.y + yOffset) + 'px',
+            top: this.props.selectedEpic.popupPosition.y + yOffset + 'px',
         };
 
         const epic = this.props.selectedEpic.epic;
@@ -79,22 +73,22 @@ class Popup extends React.Component {
 
         return (
             <div className={className} style={style}>
-            <div className='popup-summary'>{epic.summary}</div>
-            <div className='popup-container'>
-              <PopupIcon alt={'Type: ' + epic.type} imageURL={epic.typeImageURL} />
-              <PopupIcon alt={'Priority: ' + epic.priority} imageURL={epic.priorityImageURL} />
-              <span className='popup popup-flagged'>{epic.flagged ? '⚑' : ''}</span>
-              <PopupEstimate estimate={epic.estimate} />
-              <PopupKey epicKey={epic.key} />
-              <PopupAssignee assignee={epic.assignee} assigneeImageURL={epic.assigneeImageURL} />
-              <div className='popup-status-text'>
-                  {epic.status}
-                  <PopupSprint sprints={epic.sprints} />
-              </div>
-              <PopupLabels labels={epic.labels} />
+                <div className='popup-summary'>{epic.summary}</div>
+                <div className='popup-container'>
+                    <PopupIcon alt={'Type: ' + epic.type} imageURL={epic.typeImageURL} />
+                    <PopupIcon alt={'Priority: ' + epic.priority} imageURL={epic.priorityImageURL} />
+                    <span className='popup popup-flagged'>{epic.flagged ? '⚑' : ''}</span>
+                    <PopupEstimate estimate={epic.estimate} />
+                    <PopupKey epicKey={epic.key} />
+                    <PopupAssignee assignee={epic.assignee} assigneeImageURL={epic.assigneeImageURL} />
+                    <div className='popup-status-text'>
+                        {epic.status}
+                        <PopupSprint sprints={epic.sprints} />
+                    </div>
+                    <PopupLabels labels={epic.labels} />
+                </div>
+                <PopupStatus status={epic.status} />
             </div>
-            <PopupStatus status={epic.status} />
-          </div>
         );
     }
 }
@@ -105,7 +99,7 @@ class PopupSprint extends React.Component {
         if (sprints.length === 0) {
             return null;
         }
-        return <span> {sprints[sprints.length-1].name}</span>;
+        return <span> {sprints[sprints.length - 1].name}</span>;
     }
 }
 
@@ -113,8 +107,8 @@ class PopupIcon extends React.Component {
     render() {
         return (
             <span className='popup'>
-        <img src={this.props.imageURL} alt={this.props.alt} title={this.props.alt} />
-      </span>
+                <img src={this.props.imageURL} alt={this.props.alt} title={this.props.alt} />
+            </span>
         );
     }
 }
@@ -140,7 +134,9 @@ class PopupKey extends React.Component {
 
         return (
             <span className='popup-key'>
-                <a href={url} target='_blank' rel='noreferrer'>{this.props.epicKey}</a>
+                <a href={url} target='_blank' rel='noreferrer'>
+                    {this.props.epicKey}
+                </a>
             </span>
         );
     }
@@ -148,9 +144,7 @@ class PopupKey extends React.Component {
 
 class PopupEstimate extends React.Component {
     render() {
-        return (
-            <span className='popup-estimate'>{this.props.estimate === 0 ? '-' : this.props.estimate}</span>
-        );
+        return <span className='popup-estimate'>{this.props.estimate === 0 ? '-' : this.props.estimate}</span>;
     }
 }
 
@@ -165,7 +159,7 @@ class PopupStatus extends React.Component {
 
 class PopupLabels extends React.Component {
     render() {
-        const labelListItems = this.props.labels.map(label => <li key={label}>{label}</li>);
+        const labelListItems = this.props.labels.map((label) => <li key={label}>{label}</li>);
         return (
             <div className='popup-labels'>
                 <ul>{labelListItems}</ul>
@@ -192,8 +186,8 @@ class GraphApp extends React.Component {
     handleEpicSelection(val) {
         const epicKey = val.target.value;
         const selected = val.target.checked;
-        this.setState(prevState => ({
-            selectedEpics: prevState.selectedEpics.set(epicKey, selected)
+        this.setState((prevState) => ({
+            selectedEpics: prevState.selectedEpics.set(epicKey, selected),
         }));
     }
 
@@ -205,12 +199,18 @@ class GraphApp extends React.Component {
         } else {
             return (
                 <div>
-					<Graph issueGraph={this.state.issueGraph} selectedEpics={new Map(this.state.selectedEpics)} toggleMenu={this.props.toggleMenu} />
-					<EpicStats initialEstimate={this.props.initialEstimate} issueGraph={this.state.issueGraph} />
-                    <Legend issueGraph={this.state.issueGraph}
-                      selectedEpics={this.state.selectedEpics}
-                      handleEpicSelection={(epic) => this.handleEpicSelection(epic)} />
-				</div>
+                    <Graph
+                        issueGraph={this.state.issueGraph}
+                        selectedEpics={new Map(this.state.selectedEpics)}
+                        toggleMenu={this.props.toggleMenu}
+                    />
+                    <EpicStats initialEstimate={this.props.initialEstimate} issueGraph={this.state.issueGraph} />
+                    <Legend
+                        issueGraph={this.state.issueGraph}
+                        selectedEpics={this.state.selectedEpics}
+                        handleEpicSelection={(epic) => this.handleEpicSelection(epic)}
+                    />
+                </div>
             );
         }
     }
@@ -221,19 +221,21 @@ class GraphApp extends React.Component {
         const uriPrefix = this.props.issueType === 'Milestone' ? '/api/milestones/' : '/api/epics/';
 
         fetch(uriPrefix + issueKey)
-            .then(res => {
+            .then((res) => {
                 if (!res.ok) {
                     throw new Error('not ok');
                 }
                 return res.json();
-            }).then(result => {
+            })
+            .then((result) => {
                 this.setState({
                     isLoaded: true,
                     issueGraph: result,
                     selectedEpics: this.initSelectedEpics(result),
                 });
                 console.log('loaded ' + issueKey);
-            }).catch((err) => {
+            })
+            .catch((err) => {
                 console.log('failed to load ' + issueKey + ' error: ' + err);
                 this.setState({
                     isLoaded: false,
@@ -246,13 +248,24 @@ class GraphApp extends React.Component {
 class Menu extends React.Component {
     render() {
         const labelStyle = {
-            'backgroundColor': colors[this.props.issueColor]
+            backgroundColor: colors[this.props.issueColor],
         };
 
         return (
             <span className='menu-container'>
-                <label htmlFor='menu-toggle' className={`menu-toggle-label ${this.props.issueColor}`} style={labelStyle} >&#9776;</label>
-                <input type='checkbox' id='menu-toggle' checked={this.props.showMenu} onChange={() => this.props.toggleMenu()} />
+                <label
+                    htmlFor='menu-toggle'
+                    className={`menu-toggle-label ${this.props.issueColor}`}
+                    style={labelStyle}
+                >
+                    &#9776;
+                </label>
+                <input
+                    type='checkbox'
+                    id='menu-toggle'
+                    checked={this.props.showMenu}
+                    onChange={() => this.props.toggleMenu()}
+                />
                 <div className='menu'>
                     Related issues
                     <hr />
@@ -284,10 +297,13 @@ class RelatedIssues extends React.Component {
             return <div>none!</div>;
         }
 
-        const statusToEpics = issues.reduce((acc, issue) => ({
-            ...acc,
-            [issue.status]: (acc[issue.status] ?? []).concat(issue),
-        }), {});
+        const statusToEpics = issues.reduce(
+            (acc, issue) => ({
+                ...acc,
+                [issue.status]: (acc[issue.status] ?? []).concat(issue),
+            }),
+            {},
+        );
 
         if (Object.keys(statusToEpics).length === 1) {
             return <RelatedIssuesSection issues={issues} />;
@@ -308,27 +324,27 @@ class RelatedIssues extends React.Component {
 
         console.log('loading related issues for ' + issueKey);
         fetch('/api/issues/' + issueKey + '/related')
-            .then(res => {
+            .then((res) => {
                 if (!res.ok) {
                     throw new Error('not ok');
                 }
                 return res.json();
             })
-            .then(result => {
+            .then((result) => {
                 this.setState({
                     isLoaded: true,
                     issues: result,
                 });
                 console.log('loaded related issues for ' + issueKey);
-            }).catch(
-                () => {
-                    console.log('failed to load related issues for ' + issueKey);
-                    this.setState({
-                        isLoaded: false,
-                        error: true,
-                        issues: [],
-                    });
+            })
+            .catch(() => {
+                console.log('failed to load related issues for ' + issueKey);
+                this.setState({
+                    isLoaded: false,
+                    error: true,
+                    issues: [],
                 });
+            });
     }
 }
 
@@ -336,11 +352,10 @@ class RelatedIssuesSection extends React.Component {
     render() {
         const issues = this.props.issues;
 
-        const header = this.props.header === undefined
-            ? undefined
-            : (<span className='subHeader'>{this.props.header}</span>);
+        const header =
+            this.props.header === undefined ? undefined : <span className='subHeader'>{this.props.header}</span>;
 
-        const issueLinks = issues.map(iss => (
+        const issueLinks = issues.map((iss) => (
             <a key={iss.key} href={`/issues/${iss.key}`}>
                 <img src={iss.typeImageURL} />
                 {iss.key} - {iss.summary}
@@ -399,20 +414,21 @@ class Graph extends React.Component {
             layout: {
                 name: 'breadthfirst',
                 directed: true,
-                padding: 100
+                padding: 100,
             },
-            style: [{
+            style: [
+                {
                     selector: 'node',
                     style: {
-                        'content': 'data(id)',
+                        content: 'data(id)',
                         'text-opacity': 0.8,
-                        'color': '#000000',
+                        color: '#000000',
                         'font-size': 18,
                         'font-weight': 'bold',
-                        'background-color': function(ele) {
+                        'background-color': function (ele) {
                             return statusToRGB(ele.data('status'));
                         },
-                        'border-width': function(ele) {
+                        'border-width': function (ele) {
                             const sprints = ele.data('sprints');
                             if (sprints) {
                                 for (let i = 0; i < sprints.length; i++) {
@@ -423,7 +439,7 @@ class Graph extends React.Component {
                             }
                             return 2;
                         },
-                        'border-color': function(ele) {
+                        'border-color': function (ele) {
                             if (ele.data('flagged')) {
                                 return '#e82c35';
                             }
@@ -435,7 +451,7 @@ class Graph extends React.Component {
                             }
                             return '#000000';
                         },
-                        'shape': function(ele) {
+                        shape: function (ele) {
                             const labels = ele.data('labels');
                             if (labels.indexOf('devops') > -1) {
                                 return 'octagon';
@@ -447,20 +463,19 @@ class Graph extends React.Component {
                                 return 'ellipse';
                             }
                             return 'diamond';
-
-                        }
-                    }
+                        },
+                    },
                 },
                 {
                     selector: 'edge',
                     style: {
                         'curve-style': 'bezier',
-                        'width': 4,
+                        width: 4,
                         'target-arrow-shape': 'triangle',
                         'line-color': '#9dbaea',
-                        'target-arrow-color': '#9dbaea'
-                    }
-                }
+                        'target-arrow-color': '#9dbaea',
+                    },
+                },
             ],
         });
 
@@ -480,62 +495,69 @@ class Graph extends React.Component {
                 selectedEpic: {
                     epic: epic,
                     popupPosition: position,
-                }
+                },
             });
         });
 
-        cy.on('mouseover', 'node', function() {
+        cy.on('mouseover', 'node', function () {
             document.body.style.cursor = 'pointer';
         });
 
-        cy.on('mouseout', 'node', function() {
+        cy.on('mouseout', 'node', function () {
             document.body.style.cursor = 'default';
         });
 
         this.setState({
-            cy: cy
+            cy: cy,
         });
     }
 
     renderGraph(issueGraph, selectedEpics) {
-        const filteredIssues = issueGraph.issues.filter(issue => selectedEpics.get(issue.epicKey));
+        const filteredIssues = issueGraph.issues.filter((issue) => selectedEpics.get(issue.epicKey));
 
         const issueKeys = new Map(filteredIssues.map(({ key }) => [key, true]));
 
-        const issuesToGraph = filteredIssues.map(issue => ({
-            data: Object.assign({
-                id: issue.key
-            }, issue)
+        const issuesToGraph = filteredIssues.map((issue) => ({
+            data: Object.assign(
+                {
+                    id: issue.key,
+                },
+                issue,
+            ),
         }));
 
-        const issueEdges = issuesToGraph.flatMap(iss => {
+        const issueEdges = issuesToGraph.flatMap((iss) => {
             const blockingIssue = iss.data.id;
-            return issueGraph.graph[blockingIssue].flatMap(blockedIssue => {
+            return issueGraph.graph[blockingIssue].flatMap((blockedIssue) => {
                 if (!issueKeys.has(blockedIssue)) {
                     console.log('skipping edge for unselected epic issue ' + blockedIssue);
                     return [];
                 }
-                return [{
-                    data: {
-                        id: `${blockingIssue}_blocks_${blockedIssue}`,
-                        source: blockingIssue,
-                        target: blockedIssue,
-                    }
-                }];
+                return [
+                    {
+                        data: {
+                            id: `${blockingIssue}_blocks_${blockedIssue}`,
+                            source: blockingIssue,
+                            target: blockedIssue,
+                        },
+                    },
+                ];
             });
         });
 
         this.state.cy.json({
             elements: {
                 nodes: issuesToGraph,
-                edges: issueEdges
-            }
+                edges: issueEdges,
+            },
         });
-        this.state.cy.layout({
-            name: 'breadthfirst',
-            directed: true,
-            padding: 100,
-        }).run();
+        this.state.cy
+            .layout({
+                name: 'breadthfirst',
+                directed: true,
+                padding: 100,
+            })
+            .run();
     }
 }
 
@@ -564,28 +586,37 @@ class IssueGraph extends React.Component {
         const issueLabel = issue.key + ' - ' + issue.summary;
         return (
             <div>
-				<h1>
-                    <a className='home' href='/'>&#8962;</a>
-					<Menu issueKey={issue.key}
-						issueColor={issue.color}
-						toggleMenu={(show) => this.toggleMenu(show)} showMenu={this.state.showMenu} />
-					<a href={issueURL} target='_blank' rel='noreferrer'>{issueLabel}</a>
+                <h1>
+                    <a className='home' href='/'>
+                        &#8962;
+                    </a>
+                    <Menu
+                        issueKey={issue.key}
+                        issueColor={issue.color}
+                        toggleMenu={(show) => this.toggleMenu(show)}
+                        showMenu={this.state.showMenu}
+                    />
+                    <a href={issueURL} target='_blank' rel='noreferrer'>
+                        {issueLabel}
+                    </a>
                     <PopupAssignee assignee={issue.assignee} assigneeImageURL={this.props.issueAssigneeImageURL} />
-				</h1>
-				<GraphApp issueKey={issue.key}
+                </h1>
+                <GraphApp
+                    issueKey={issue.key}
                     issueType={issue.type}
-					initialEstimate={issue.initialEstimate}
-					toggleMenu={(show) => this.toggleMenu(show)} />
-			</div>
+                    initialEstimate={issue.initialEstimate}
+                    toggleMenu={(show) => this.toggleMenu(show)}
+                />
+            </div>
         );
     }
 
     toggleMenu(show) {
-        this.setState(prevState => ({
+        this.setState((prevState) => ({
             ...prevState,
             ...{
                 showMenu: show === undefined ? !prevState.showMenu : show,
-            }
+            },
         }));
     }
 
@@ -594,81 +625,91 @@ class IssueGraph extends React.Component {
 
         console.log('loading related issues for ' + issueKey);
         fetch('/api/issues/' + issueKey)
-            .then(res => {
+            .then((res) => {
                 if (!res.ok) {
                     throw new Error('not ok');
                 }
                 return res.json();
             })
-            .then(result => {
-                this.setState(prevState => ({
+            .then((result) => {
+                this.setState((prevState) => ({
                     ...prevState,
                     ...{
                         isLoaded: true,
                         error: false,
                         issue: result.issue,
                         jiraHost: result.jiraHost,
-                    }
+                    },
                 }));
                 const issue = {
                     key: this.props.issueKey,
-                    summary: result.issue.summary
+                    summary: result.issue.summary,
                 };
                 pushRecentIssue(issue);
                 console.log('loaded issue ' + issueKey);
-            }).catch(
-                (err) => {
-                    console.log('failed to load issue ' + issueKey + ' error: ' + err);
-                    this.setState(prevState => ({
-                        ...prevState,
-                        ...{
-                            isLoaded: false,
-                            error: true,
-                            issue: null,
-                            jiraHost: null,
-                        }
-                    }));
-                });
+            })
+            .catch((err) => {
+                console.log('failed to load issue ' + issueKey + ' error: ' + err);
+                this.setState((prevState) => ({
+                    ...prevState,
+                    ...{
+                        isLoaded: false,
+                        error: true,
+                        issue: null,
+                        jiraHost: null,
+                    },
+                }));
+            });
     }
 }
 
 class EpicStats extends React.Component {
     render() {
         const byStatus = this.getBreakdownByStatus();
-        const initialEstimateRow = this.props.initialEstimate !== 0 ? (
-            <tr className='initialEstimate'>
-                <td>Initial Estimate</td>
-                <td className='points'>{this.props.initialEstimate}</td>
-            </tr>
-        ) : undefined;
-
-        const statusRows = [statuses.Backlog, statuses.InProgress, statuses.Closed].flatMap(status => {
-            return byStatus[status] !== undefined ? [(
-                <tr key={status}>
-                    <td>{status}</td>
-                    <td className='points'>{byStatus[status]}</td>
+        const initialEstimateRow =
+            this.props.initialEstimate !== 0 ? (
+                <tr className='initialEstimate'>
+                    <td>Initial Estimate</td>
+                    <td className='points'>{this.props.initialEstimate}</td>
                 </tr>
-            )] : [];
+            ) : undefined;
+
+        const statusRows = [statuses.Backlog, statuses.InProgress, statuses.Closed].flatMap((status) => {
+            return byStatus[status] !== undefined
+                ? [
+                      <tr key={status}>
+                          <td>{status}</td>
+                          <td className='points'>{byStatus[status]}</td>
+                      </tr>,
+                  ]
+                : [];
         });
 
         const totalPoints = Object.values(byStatus).reduce((sum, statusPoints) => sum + statusPoints, 0);
-        const totalPointsRow = totalPoints > 0 ? (
-            <tr className='total'><td>Total</td><td className='points'>{totalPoints}</td></tr>
-        ) : undefined;
+        const totalPointsRow =
+            totalPoints > 0 ? (
+                <tr className='total'>
+                    <td>Total</td>
+                    <td className='points'>{totalPoints}</td>
+                </tr>
+            ) : undefined;
         const closedPoints = byStatus[statuses.Closed] ?? 0;
-        const closedPointsRow = totalPoints > 0 ? (
-            <tr className='total'>
-                <td colSpan='2'>
-                    {closedPoints}/{totalPoints} Closed ({Math.round(closedPoints / totalPoints * 100)}%)
-                </td>
-            </tr>
-        ) : undefined;
+        const closedPointsRow =
+            totalPoints > 0 ? (
+                <tr className='total'>
+                    <td colSpan='2'>
+                        {closedPoints}/{totalPoints} Closed ({Math.round((closedPoints / totalPoints) * 100)}%)
+                    </td>
+                </tr>
+            ) : undefined;
 
         return (
             <div className='epicStats'>
                 <table>
                     <thead>
-                        <tr><th colSpan='2'>Point Breakdown</th></tr>
+                        <tr>
+                            <th colSpan='2'>Point Breakdown</th>
+                        </tr>
                     </thead>
                     <tbody>
                         {initialEstimateRow}
@@ -677,7 +718,7 @@ class EpicStats extends React.Component {
                         {closedPointsRow}
                     </tbody>
                 </table>
-			</div>
+            </div>
         );
     }
 
@@ -703,13 +744,16 @@ class Legend extends React.Component {
         const selectedEpics = this.props.selectedEpics;
 
         //TODO: flatten the epics once in GraphApp to resolve a prop of epic->color code and state for epic->selected
-        const epicKeyToInfo = issues.reduce((map, iss) => ({
-            ...map,
-            [iss.epicKey]: {
-                color: iss.color,
-                epicName: iss.epicName,
-            },
-        }), {});
+        const epicKeyToInfo = issues.reduce(
+            (map, iss) => ({
+                ...map,
+                [iss.epicKey]: {
+                    color: iss.color,
+                    epicName: iss.epicName,
+                },
+            }),
+            {},
+        );
 
         if (Object.keys(epicKeyToInfo).length <= 1) {
             return null;
@@ -717,15 +761,20 @@ class Legend extends React.Component {
 
         const elements = Object.entries(epicKeyToInfo).map(([epicKey, epicInfo]) => {
             const highlightStyle = {
-                'color': colors[epicInfo.color]
+                color: colors[epicInfo.color],
             };
             return (
                 <div key={epicKey}>
                     <label>
-                        <input type='checkbox'
-                               checked={selectedEpics.get(epicKey)} value={epicKey}
-                               onChange={this.props.handleEpicSelection} />
-                        <span className='epicHighlight' style={highlightStyle}>&#9679;</span>
+                        <input
+                            type='checkbox'
+                            checked={selectedEpics.get(epicKey)}
+                            value={epicKey}
+                            onChange={this.props.handleEpicSelection}
+                        />
+                        <span className='epicHighlight' style={highlightStyle}>
+                            &#9679;
+                        </span>
                         <span className='legendTooltip'>
                             {epicKey}
                             <span className='legendTooltipText'>{epicInfo.epicName}</span>
@@ -743,6 +792,4 @@ class Legend extends React.Component {
     }
 }
 
-export {
-    RoutedIssueGraph
-};
+export { RoutedIssueGraph };

--- a/src/IssueList.jsx
+++ b/src/IssueList.jsx
@@ -34,7 +34,7 @@ class IssueList extends React.Component {
 
 class Issue extends React.Component {
     render() {
-        const path = '/issues/' + this.props.issueKey;
+        const path = `/issues/${this.props.issueKey}`;
         return (
             <li>
                 <Link to={path} key={this.props.issueKey}>

--- a/src/IssueList.jsx
+++ b/src/IssueList.jsx
@@ -1,19 +1,12 @@
 import React from 'react';
-import {
-    Link
-} from 'react-router-dom';
-import {
-    getRecentIssues
-} from './recent';
+import { Link } from 'react-router-dom';
+import { getRecentIssues } from './recent';
 import './issueList.css';
 
 class IssueList extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            issues: [],
-        };
-    }
+    state = {
+        issues: [],
+    };
 
     render() {
         if (this.state.issues.length === 0) {
@@ -22,10 +15,10 @@ class IssueList extends React.Component {
         const issues = this.state.issues.map((e) => <Issue key={e.key} issueKey={e.key} summary={e.summary} />);
         return (
             <div className='issueList'>
-            <h1>jiragraph</h1>
-            <h3>Recently viewed issues</h3>
-            <ul>{issues}</ul>
-          </div>
+                <h1>jiragraph</h1>
+                <h3>Recently viewed issues</h3>
+                <ul>{issues}</ul>
+            </div>
         );
     }
 
@@ -33,7 +26,7 @@ class IssueList extends React.Component {
         const recentIssues = getRecentIssues();
         if (recentIssues) {
             this.setState({
-                issues: recentIssues
+                issues: recentIssues,
             });
         }
     }
@@ -44,12 +37,12 @@ class Issue extends React.Component {
         const path = '/issues/' + this.props.issueKey;
         return (
             <li>
-            <Link to={path} key={this.props.issueKey}>{this.props.issueKey} - {this.props.summary}</Link>
-          </li>
+                <Link to={path} key={this.props.issueKey}>
+                    {this.props.issueKey} - {this.props.summary}
+                </Link>
+            </li>
         );
     }
 }
 
-export {
-    IssueList
-};
+export { IssueList };

--- a/src/colors.js
+++ b/src/colors.js
@@ -12,9 +12,7 @@ const colors = {
     color_11: '#79E2F2',
     color_12: '#7A869A',
     color_13: '#57D9A3',
-    color_14: '#FF8F73'
+    color_14: '#FF8F73',
 };
 
-export {
-    colors
-};
+export { colors };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,37 +1,27 @@
 import React from 'react';
-import {
-    render
-} from 'react-dom';
-import {
-    BrowserRouter,
-    Routes,
-    Route,
-    Outlet,
-} from 'react-router-dom';
-import {
-    IssueList
-} from './IssueList';
-import {
-    RoutedIssueGraph
-} from './Graph';
-import {
-    NotFound
-} from './Errors';
+import { render } from 'react-dom';
+import { BrowserRouter, Routes, Route, Outlet } from 'react-router-dom';
+import { IssueList } from './IssueList';
+import { RoutedIssueGraph } from './Graph';
+import { NotFound } from './Errors';
 
 render(
     <BrowserRouter>
         <Routes>
             <Route path='/' element={<IssueList />} />
             <Route path='/index.html' element={<IssueList />} />
-            <Route path='issues' element={
-                <main>
-                  <Outlet />
-                </main>
-            }>
+            <Route
+                path='issues'
+                element={
+                    <main>
+                        <Outlet />
+                    </main>
+                }
+            >
                 <Route path=':issueKey' element={<RoutedIssueGraph />} />
             </Route>
             <Route path='*' element={<NotFound />} />
         </Routes>
     </BrowserRouter>,
-    document.getElementById('root')
+    document.getElementById('root'),
 );

--- a/src/recent.js
+++ b/src/recent.js
@@ -15,7 +15,7 @@ const getRecentIssues = () => {
         try {
             parsed = JSON.parse(rawRecentIssues);
         } catch (e) {
-            console.log('failed to parse recent-epics from local storage: ' + e);
+            console.log(`failed to parse recent-epics from local storage: ${e}`);
         }
         if (parsed && parsed.constructor === Array) {
             return parsed;

--- a/src/recent.js
+++ b/src/recent.js
@@ -2,7 +2,7 @@ const localStorageKey = 'recent-epics';
 const maxIssueCount = 10;
 
 const hasLocalStorage = () => {
-    return typeof(Storage) !== 'undefined';
+    return typeof Storage !== 'undefined';
 };
 
 const getRecentIssues = () => {
@@ -43,7 +43,4 @@ const pushRecentIssue = (issue) => {
     localStorage.setItem(localStorageKey, JSON.stringify(issues));
 };
 
-export {
-    getRecentIssues,
-    pushRecentIssue
-};
+export { getRecentIssues, pushRecentIssue };

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,12 +2,12 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-	plugins: [react()],
-	server: {
-		proxy: {
-			'/api': {
-				target: 'http://localhost:8080'
-			}
-		}
-	}
+    plugins: [react()],
+    server: {
+        proxy: {
+            '/api': {
+                target: 'http://localhost:8080',
+            },
+        },
+    },
 });


### PR DESCRIPTION
Prettier is the most common formatting tool for front-end code these days, and it has [very few options](https://prettier.io/docs/en/option-philosophy.html) so there isn't actually much to set up with it. `eslint-plugin-prettier` ties that formatting preference into the linting checks, which both helps with ensuring the formatting is being used AND provides a way to auto-fix formatting through most code editors (via `eslint`'s existing `--fix` command and behavior)

One particular `TODO` I was having some trouble with is that _theoretically_ we shouldn't need to duplicate the configuration options within both ESLint and `.prettierrc`, but [the configuration to do so](https://github.com/prettier/eslint-plugin-prettier#options) wasn't working for me

The options I've set here are aimed at:
* consistency (especially with ESLint settings) - this is namely in the form of what style of quotes to use
* minimizing the impact on the existing code style - `tabWidth` in particular was aimed at this, and the print width (line length) was chosen to minimize the impact against the natural length things have seemed to have so far
* minimize future diffs - trailing commas are worth 10x their weight for how much more precise diffs become. [`bracketLine`](https://prettier.io/docs/en/options.html#bracket-line) isn't specifically set, but is a similar option that minimizes the impact of JSX diffs - it already defaults to a separate line so no override is necessary

I'm not particularly invested in any setting, so feel free to treat this as just a framework for interacting with those available configurations to find the style you prefer!